### PR TITLE
#114 Add the new Rake task without implementation

### DIFF
--- a/features/rake.feature
+++ b/features/rake.feature
@@ -1,0 +1,13 @@
+Feature: Rake Task
+  Scenario: For now we failed if run rake task
+    Given It is Unix
+    And I have a "Rakefile" file with content:
+    """
+    require 'pdd/rake_task'
+    PDD::RakeTask.new
+    """
+    When I run bash with "rake pdd"
+    Then Exit code is not zero
+    # @todo #114:30m For now, there haven't a proper method to check STDERR.
+    #  In this test I've tried to check the output with Stdout contains but there is not working.
+    #  Needs a proper alternative to check stderr.

--- a/features/step_definitions/steps.rb
+++ b/features/step_definitions/steps.rb
@@ -111,6 +111,12 @@ When(/^I run bash with$/) do |text|
   @exitstatus = $CHILD_STATUS.exitstatus
 end
 
+When(/^I run bash with "([^"]*)"$/) do |text|
+  FileUtils.copy_entry(@cwd, File.join(@dir, 'pdd'))
+  @stdout = `#{text}`
+  @exitstatus = $CHILD_STATUS.exitstatus
+end
+
 Given(/^It is Unix$/) do
   pending if Gem.win_platform?
 end

--- a/lib/pdd/rake_task.rb
+++ b/lib/pdd/rake_task.rb
@@ -1,0 +1,13 @@
+require 'rake'
+require 'rake/tasklib'
+
+# PDD Rake task
+module PDD
+  # Rake task
+  class RakeTask < Rake::TaskLib
+    def initialize
+      # @todo #114:30m We need to create implementation of this class.
+      abort('NOT IMPLEMENTED')
+    end
+  end
+end

--- a/test/test_rake_task.rb
+++ b/test/test_rake_task.rb
@@ -1,0 +1,14 @@
+require 'minitest/autorun'
+require 'tmpdir'
+require 'rake'
+require_relative '../lib/pdd/rake_task'
+
+# Test for RakeTask
+class TestRakeTask < Minitest::Test
+  def test_base
+    error = assert_raises SystemExit do
+      PDD::RakeTask.new
+    end
+    assert_equal('NOT IMPLEMENTED', error.message)
+  end
+end


### PR DESCRIPTION
This fixes #114. I've added a skeleton without implementation but with PDD todos.
