### PR TITLE
#135 Replacing run to run following commands

### DIFF
--- a/features/rake.feature
+++ b/features/rake.feature
@@ -6,9 +6,10 @@ Feature: Rake Task
     require 'pdd/rake_task'
     PDD::RakeTask.new
     """
-    # @todo #126:30m For now, there is a warning when I run the test.
-    #  Needs to replace the current call to not deprecated one.
-    When I run "rake pdd"
+    When I run the following commands with `bash`:
+    """bash
+    rake pdd
+    """
     Then the exit status should be 1
     And the stderr should contain:
     """


### PR DESCRIPTION
This is the fix for #135. I've replaced `run` to `run the following commands with bash`. And no one warning about deprecated methods in not shown up.