### PR TITLE
#149: remove restriction on max number of leading spaces on next line

### DIFF
--- a/features/catches_broken_puzzles.feature
+++ b/features/catches_broken_puzzles.feature
@@ -23,21 +23,6 @@ Feature: Catches Broken Puzzles
     When I run pdd it fails with "Space expected"
     When I run pdd it fails with "puzzle at line #6"
 
-  Scenario: Throwing exception on another broken puzzle
-    Given I have a "Sample.java" file with content:
-    """
-    public class Main {
-      /**
-       * @todo #13 This puzzle has an incorrect format
-       *    because its second line starts with too many spaces
-       */
-      public void main(String[] args) {
-        // later
-      }
-    }
-    """
-    When I run pdd it fails with "Too many leading spaces"
-
   Scenario: Throwing exception on yet another broken puzzle
     Given I have a "Sample.java" file with content:
     """

--- a/lib/pdd/source.rb
+++ b/lib/pdd/source.rb
@@ -145,13 +145,6 @@ against the rules explained here: https://github.com/yegor256/pdd#how-to-format"
           raise Error, "Space expected at #{start + i + 2}:#{prefix.length}; \
 make sure all lines in the puzzle body have a single leading space."
         end
-        .each_with_index do |t, i|
-          next if t !~ /^\s{2,}/
-          raise Error, "Too many leading spaces \
-at #{start + i + 2}:#{prefix.length}; \
-make sure all lines that include the puzzle body start \
-at position ##{prefix.length + 1}."
-        end
         .map { |t| t[1, t.length] }
     end
 

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -34,6 +34,9 @@ class TestSource < Minitest::Test
       File.write(
         file,
         "
+        * \x40todo #56:30min this is a
+        *       multi-line comment!
+        Something else
         * \x40todo #44 привет,
         *  how are you\t\tdoing?
         * -something else
@@ -43,11 +46,11 @@ class TestSource < Minitest::Test
         "
       )
       list = PDD::VerboseSource.new(file, PDD::Source.new(file, 'hey')).puzzles
-      assert_equal 2, list.size
+      assert_equal 3, list.size
       puzzle = list.first
       assert_equal '2-3', puzzle.props[:lines]
-      assert_equal 'привет, how are you doing?', puzzle.props[:body]
-      assert_equal '44', puzzle.props[:ticket]
+      assert_equal 'this is a multi-line comment!', puzzle.props[:body]
+      assert_equal '56', puzzle.props[:ticket]
       assert puzzle.props[:author].nil?
       assert puzzle.props[:email].nil?
       assert puzzle.props[:time].nil?

--- a/test/test_source.rb
+++ b/test/test_source.rb
@@ -34,9 +34,6 @@ class TestSource < Minitest::Test
       File.write(
         file,
         "
-        * \x40todo #56:30min this is a
-        *       multi-line comment!
-        Something else
         * \x40todo #44 привет,
         *  how are you\t\tdoing?
         * -something else
@@ -46,14 +43,34 @@ class TestSource < Minitest::Test
         "
       )
       list = PDD::VerboseSource.new(file, PDD::Source.new(file, 'hey')).puzzles
-      assert_equal 3, list.size
+      assert_equal 2, list.size
       puzzle = list.first
       assert_equal '2-3', puzzle.props[:lines]
-      assert_equal 'this is a multi-line comment!', puzzle.props[:body]
-      assert_equal '56', puzzle.props[:ticket]
+      assert_equal 'привет, how are you doing?', puzzle.props[:body]
+      assert_equal '44', puzzle.props[:ticket]
       assert puzzle.props[:author].nil?
       assert puzzle.props[:email].nil?
       assert puzzle.props[:time].nil?
+    end
+  end
+
+  def test_parsing_leading_spaces
+    Dir.mktmpdir 'test' do |dir|
+      file = File.join(dir, 'a.txt')
+      File.write(
+        file,
+        "
+        * \x40todo #56:30min this is a
+        *       multi-line
+        *     comment!
+        "
+      )
+      list = PDD::VerboseSource.new(file, PDD::Source.new(file, 'hey')).puzzles
+      assert_equal 1, list.size
+      puzzle = list.first
+      assert_equal '2-4', puzzle.props[:lines]
+      assert_equal 'this is a multi-line comment!', puzzle.props[:body]
+      assert_equal '56', puzzle.props[:ticket]
     end
   end
 


### PR DESCRIPTION
This fix is backwards compatible. I think in other to prevent micro configurations/rules that are not essential to the generation of puzzles e.g setting configuration option for max number of leading spaces, it is best to remove that restriction on the number of leading spaces on the next line of a puzzle.
That's the idea behind this solution :)